### PR TITLE
易用性改善

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 var vscode = require('vscode');
+var path = require('path');
 var qnUpload = require('./lib/upload');
 
 // this method is called when your extension is activated
@@ -22,8 +23,9 @@ function activate(context) {
     // The commandId parameter must match the command field in package.json
     var disposable = vscode.commands.registerCommand('extension.qiniu.upload', function () {
         // The code you place here will be executed every time your command is executed
-
         var editor = window.activeTextEditor;
+        var mdFilePath = editor.document.fileName;
+        var mdFileName = path.basename(mdFilePath, path.extname(mdFilePath));
 
         if (!editor) {
             window.showErrorMessage("没有打开编辑窗口");
@@ -36,7 +38,7 @@ function activate(context) {
             placeHolder: '输入一个本地图片地址'
         }).then(function(path){
 
-            return qnUpload(config, path);
+            return qnUpload(config, path, mdFileName);
 
         }, function(err){
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -41,6 +41,9 @@ module.exports = function(config, file, mdFile) {
 
     var domain = config.domain;
 
+    if (/^".+"$/.test(file)) {
+        file = file.substring(1, file.length - 1);
+    }
     //要上传文件的本地路径
     var localFile = file;
     

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -10,7 +10,7 @@ function uptoken(bucket, key) {
 }
 
 // 默认参数
-function fileParam(file){
+function fileParam(file, mdFile){
     var dt = new Date();
     var y = dt.getFullYear();
     var m = dt.getMonth() + 1;
@@ -27,11 +27,12 @@ function fileParam(file){
         date: date,
         dateTime: date + '' + h + '' + mm + '' + s,
         fileName: path.basename(file, ext),
-        ext: ext
+        ext: ext,
+        mdFileName: mdFile
     }
 }
 
-module.exports = function(config, file) {
+module.exports = function(config, file, mdFile) {
     qiniu.conf.ACCESS_KEY = config.access_key;
     qiniu.conf.SECRET_KEY = config.secret_key;
 
@@ -43,7 +44,7 @@ module.exports = function(config, file) {
     //要上传文件的本地路径
     var localFile = file;
     
-    var param = fileParam(file);
+    var param = fileParam(file, mdFile);
     
     //上传到七牛后保存的文件名
     var remotePath = (config.remotePath + '${ext}').replace(paramExp, function(exp, prop){


### PR DESCRIPTION
# 需求

## 自动去掉文件路径两边双引号

- 在Windows下shift+右键点击文件，选择“复制为路径”是获取文件路径的比较快捷的方式，但是复制出来的却有双引号，需要手动去除 。

> 复制路径的结果：`"C:\Users\43855\Desktop\QQ截图20170411213034.png"`

## 支持${mdFileName}参数

- 希望能在在七牛的内容管理处可以方便地根据文章标题找到对应的图片，方便管理。

> 使用示例：`"qiniu.remotePath": "${mdFileName}-${dateTime}"`

# 效果
![test](https://cloud.githubusercontent.com/assets/14769033/24940807/34ad4864-1f78-11e7-842e-fc66ce7f3dba.gif)
